### PR TITLE
Changes to get closer to parity with TBv1

### DIFF
--- a/Src/controlmanager.c
+++ b/Src/controlmanager.c
@@ -74,10 +74,14 @@ static void 					adjSubj( int adj ){								// adjust current Subj # in TBook
 		nS = 0;
 	logEvtNI( "chngSubj", "iSubj", nS );
 	TBook.iSubj = nS;
+	TBook.iMsg = -1; // "next" will yield 0, "prev" -> -2 -> numMessages-1
 }
 
 
 static void 					adjMsg( int adj ){								// adjust current Msg # in TBook
+	// If no subject is selected, do nothing.
+  if (TBook.iSubj < 0 || TBook.iSubj >= TBPkg->nSubjs)
+		return;
 	short nM = TBook.iMsg + adj; 
 	short numM = TBPkg->TBookSubj[ TBook.iSubj ]->NMsgs;
 	if ( nM < 0 ) 
@@ -90,6 +94,9 @@ static void 					adjMsg( int adj ){								// adjust current Msg # in TBook
 
 
 void 					playSubjAudio( char *arg ){				// play current Subject: arg must be 'nm', 'pr', or 'msg'
+	// If no subject is selected, do nothing.
+  if (TBook.iSubj < 0 || TBook.iSubj >= TBPkg->nSubjs)
+		return;
 	tbSubject * tbS = TBPkg->TBookSubj[ TBook.iSubj ];
 	char path[MAX_PATH];
 	char *nm = NULL;
@@ -137,7 +144,7 @@ void 					showPkg( ){										// debug print Package iPkg
 
 void						changePackage(){											// switch to last played package name
 	TBPkg = TBPackage[ iPkg ];
-	TBook.iSubj = 0;
+	TBook.iSubj = -1; // makes "next subject" go to the first subject.
 	TBook.iMsg = 0;
 	logEvtNS( "ChgPkg", "Pkg", TBPkg->packageName );  
 	showPkg();
@@ -433,7 +440,7 @@ void 					executeCSM( void ){								// execute TBook control state machine
 	
 	TBook.volume = TB_Config.default_volume;
 	TBook.speed = TB_Config.default_speed;
-	TBook.iSubj = 0;
+	TBook.iSubj = -1; // makes "next subject" go to the first subject.
 	TBook.iMsg = 0;
 
 	// set initialState & do actions
@@ -539,7 +546,7 @@ void 									initControlManager( void ){				// initialize control manager
 
 		findPackages( );		// sets iPkg & TBPackage to shortest name
 		
-		TBook.iSubj = 0;
+  	TBook.iSubj = -1; // makes "next subject" go to the first subject.
 		TBook.iMsg = 1;
 		
 		// power timer is set to input configuration by 1st 15sec check

--- a/TbFiles/control.def
+++ b/TbFiles/control.def
@@ -2,7 +2,7 @@
   config: {   
     minShortPressMS: 50, 
     minLongPressMS: 1000, 
-    default_volume: 7, 
+    default_volume: 6, 
     default_speed: 5, 
     shortIdleMS: 5000, 
     longIdleMS: 20000, 
@@ -48,7 +48,7 @@
                      starMinus: stOnUpdate },
   },  
   CStates: {  
-    stWakeup:     { Actions: [ LED(_), bgLED(G_9), playSys(welcome) ],      CGroups:[ whenAwake, whenPlaying ], AudioDone: stPromptSubj },
+    stWakeup:     { Actions: [ LED(_), bgLED(G_9), changePkg, playSys(welcome) ],      CGroups:[ whenAwake, whenPlaying, whenNav ], AudioDone: stPromptSubj },
     stPromptSubj: { Actions: [ playSys(rh_for_subj) ],                      CGroups:[ whenAwake, whenPlaying ], AudioDone: stWait },
     stWait:       {                                                         CGroups:[ whenAwake, whenNav, whenIdle ] },
     stSleepy:     { Actions: [ bgLED(O_9),  saveSt(1),  setTimer(10000) ],  CGroups:[ whenAwake ], allKeys: stUnSleepy, Timer: stGoSleep },
@@ -66,10 +66,12 @@
     stPlayJumpBack: { Actions: [ posAdj(-7) ],                              CGroups:[ whenAwake, whenPlaying, whenNav ] },
     stPlayJumpFwd:  { Actions: [ posAdj(60) ],                              CGroups:[ whenAwake, whenPlaying, whenNav ] },
     
-    stOnPrevSubj: { Actions: [ subjAdj(-1),  playSubj(nm) ],                CGroups:[ whenAwake, whenPlaying, whenNav ] },
-    stOnNextSubj: { Actions: [ subjAdj( 1),  playSubj(nm) ],                CGroups:[ whenAwake, whenPlaying, whenNav ] },
-    stOnNextMsg:  { Actions: [ msgAdj( -1),  playSubj(msg) ],               CGroups:[ whenAwake, whenPlaying, whenNav ] },
-    stOnPrevMsg:  { Actions: [ msgAdj(  1),  playSubj(msg) ],               CGroups:[ whenAwake, whenPlaying, whenNav ] },
+    stOnPrevSubj: { Actions: [ subjAdj(-1),  playSubj(nm) ],                CGroups:[ whenAwake, whenPlaying, whenNav ], AudioDone: stInvitation },
+    stOnNextSubj: { Actions: [ subjAdj( 1),  playSubj(nm) ],                CGroups:[ whenAwake, whenPlaying, whenNav ], AudioDone: stInvitation },
+    stInvitation: { Actions: [ playSubj(pr) ],                              CGroups:[ whenAwake, whenPlaying, whenNav ], AudioDone: stPromptNextSubj },
+    stPromptNextSubj: { Actions: [ playSys(rh_for_nxt_subj) ],              CGroups:[ whenAwake, whenPlaying, whenNav ] },
+    stOnPrevMsg:  { Actions: [ msgAdj( -1),  playSubj(msg) ],               CGroups:[ whenAwake, whenPlaying, whenNav ] },
+    stOnNextMsg:  { Actions: [ msgAdj(  1),  playSubj(msg) ],               CGroups:[ whenAwake, whenPlaying, whenNav ] },
     stOnFeedback: { Actions: [ playSys(cir_record_ideas) ],                 CGroups:[ whenAwake, whenFeedback ] },
     stOnOptions:  {                                                         CGroups:[ whenAwake ] },
 


### PR DESCRIPTION
Make TBv2 behave more like TBv1

Changes to control.def to:
- Announce playlist with name, then invitation, then "To try another subject, press the right hand.".
- Respond to nav events during "Welcome to the Amplio Talking Book!"
- Perform a harder reset on "Home" key.

Changes to controlmanager.c to:
- Reset current playlist on major events, so that "nextSubject" works properly.
- Reset current message on playlist change, so that "nextMessage" works properly.