### PR TITLE
Set the timestamp of files when they are created.

### DIFF
--- a/Src/fs_get_time.c
+++ b/Src/fs_get_time.c
@@ -1,0 +1,13 @@
+#include "main.h"
+#include "tbook.h"
+
+/// \brief Callback to retrieve a time to set as a file's timestamp.
+/// \param[out] time                     fsTime structure to be filled in. 
+/// \param[out] buf                      pointer to string buffer.
+/// \return     execution status \ref fsStatus
+///               - fsOK               = Operation successful.
+///               - fsError            = Failed to get the current time.
+fsStatus fs_get_time (fsTime *time) {
+  getRTC(time);
+  return fsOK;
+}

--- a/Src/logger.c
+++ b/Src/logger.c
@@ -143,6 +143,7 @@ void						logPowerUp( bool reboot ){											// re-init logger after reboot, U
 	//checkLog();	//DEBUG
 	//if ( !openLog(false) ) return;
 	
+  // "M0:/system/bootcount.txt"
 	char * boot = loadLine( line, TBP[ pBOOTCNT ], &bootDt ); 
 	int bootcnt = 1;		// if file not there-- first boot
 	if ( boot!=NULL ) sscanf( boot, " %d", &bootcnt );
@@ -186,6 +187,9 @@ void						logPowerUp( bool reboot ){											// re-init logger after reboot, U
 		return;
 	}
 
+  // Read some bytes from "M0:/system/control.def"; as a side effect, query the timestamp of "control.def"
+  // and use that to set the RTC clock.
+  // TODO: use a file that is only used to set the clock.
 	char * status = loadLine( line, TBP[ pCSM_DEF ], &verDt );			// control.def file exists-- when created?
 	dateStr( dt, verDt );
 	logEvtNSNS( "TB_CSM", "dt", dt, "ver", status );

--- a/Src/tbUtil.c
+++ b/Src/tbUtil.c
@@ -338,6 +338,7 @@ void 										initIDs(){																		// initialize CPU_ID & TB_ID strings
 //	loadTBookName();
 }
 
+
 //
 // timestamps & RTC, allocation, fexists
 struct {
@@ -351,6 +352,31 @@ struct {
 	uint8_t		tenths;
 	uint8_t		pm;
 } lastRTC, firstRTC;
+
+
+/// \brief Gets the current time from RTC into a fsTime structure.
+/// \param[out] fsTime      fsTime structure to be filled in.
+void getRTC(struct _fsTime *fsTime) {
+    int pDt=0,Dt=1, pTm=0,Tm=1;
+    while (pDt != Dt || pTm != Tm){
+        pDt = Dt;
+        pTm = Tm;
+        Dt = RTC->DR;
+        Tm = RTC->TR;
+    }
+
+    // This is going suck in the year 2100. But it would break in 2107 anyway.
+    // The time format allows years 1980 to 2107. The RTC only allows years % 100.
+    fsTime->year = ((Dt>>20) & 0xF)*10 + ((Dt>>16) & 0xF) + 2000;
+    fsTime->mon = ((Dt>>12) & 0x1)*10 + ((Dt>>8) & 0xF);
+    fsTime->day =((Dt>> 4) & 0x3)*10 + (Dt & 0xF);
+
+    fsTime->hr = ((Tm>>20) & 0x3)*10 + ((Tm>>16) & 0xF);
+    fsTime->min = ((Tm>>12) & 0x7)*10 + ((Tm>>8) & 0xF);
+    fsTime->sec = ((Tm>> 4) & 0x7)*10 + (Tm & 0xF);
+}
+
+
 void 										showRTC( ){
 	int pDt=0,Dt=1, pTm=0,Tm=1;
 	while (pDt != Dt || pTm != Tm){
@@ -378,6 +404,8 @@ void 										showRTC( ){
 	sprintf(dttm, "%s %d-%s-%d %d:%02d:%02d", wkdy[day], date, month[mon], yr, hr,min,sec );
 	logEvtNS( "RTC", "DtTm", dttm );
 }
+
+
 void 										measureSystick(){
 	const int NTS = 6;
 	int msTS[ NTS ], minTS = 1000000, maxTS=0, sumTS=0;


### PR DESCRIPTION
Keil has a feature to set the time of a file when the file is created/modified. (It may also set last access, etc, but I'm not sure and don't really care about accessed.)

For some reason, they built all of the plumbing to let the file time be set, but never actually implemented it; that's left as an exercise for the user.